### PR TITLE
fix remove_weight_norm() with wrong block

### DIFF
--- a/model/res_stack.py
+++ b/model/res_stack.py
@@ -31,6 +31,6 @@ class ResStack(nn.Module):
 
     def remove_weight_norm(self):
         for block, shortcut in zip(self.blocks, self.shortcuts):
-            nn.utils.remove_weight_norm(block[1])
-            nn.utils.remove_weight_norm(block[3])
+            nn.utils.remove_weight_norm(block[2])
+            nn.utils.remove_weight_norm(block[4])
             nn.utils.remove_weight_norm(shortcut)


### PR DESCRIPTION
#35 has added a `nn.ReflectionPad1d(3**i)`, and the position of `weight_norm()` has been updated.